### PR TITLE
Create cicdServerSetup.sh

### DIFF
--- a/cicdServerSetup.sh
+++ b/cicdServerSetup.sh
@@ -1,0 +1,5 @@
+# this script is intended to keep track of the steps done to setup the CICD server. 
+# Many of the steps may be commented out to begin with just to serve as documentation. However, the intention is that this could be runnable at some point.
+
+# Add VIM
+# apt update


### PR DESCRIPTION
intended to be a script that could be run to set up a bare Linux Mint machine for running CICD tasks